### PR TITLE
fix: adjust backend config ports and credentials to match Docker Compose

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,15 +3,15 @@ PORT=8000
 NODE_ENV=development
 
 # Database
-DATABASE_URL=postgresql://streamflow:streamflow@localhost:5432/streamflow
+DATABASE_URL=postgresql://streamflow:streamflow@localhost:5434/streamflow
 
 # Redis
-REDIS_URL=redis://localhost:6379
+REDIS_URL=redis://localhost:6380
 
 # MinIO
-MINIO_ENDPOINT=localhost:9000
+MINIO_ENDPOINT=localhost:9002
 MINIO_USER=streamflow
-MINIO_PASSWORD=streamflow
+MINIO_PASSWORD=streamflow123
 MINIO_BUCKET_RAW=raw-uploads
 MINIO_BUCKET_VOD=production-vod
 MINIO_BUCKET_THUMBS=thumbnails

--- a/backend/deno.json
+++ b/backend/deno.json
@@ -22,7 +22,6 @@
     "@types/bcryptjs": "npm:@types/bcryptjs@^2.4.6"
   },
   "compilerOptions": {
-    "allowJs": true,
     "lib": ["deno.window"],
     "strict": true
   },

--- a/backend/src/utils/env.ts
+++ b/backend/src/utils/env.ts
@@ -4,13 +4,13 @@ export const env = {
   PORT: parseInt(Deno.env.get('PORT') || '8000'),
   NODE_ENV: Deno.env.get('NODE_ENV') || 'development',
   
-  DATABASE_URL: Deno.env.get('DATABASE_URL') || 'postgresql://streamflow:streamflow@localhost:5433/streamflow',
+  DATABASE_URL: Deno.env.get('DATABASE_URL') || 'postgresql://streamflow:streamflow@localhost:5434/streamflow',
   
-  REDIS_URL: Deno.env.get('REDIS_URL') || 'redis://localhost:6379',
+  REDIS_URL: Deno.env.get('REDIS_URL') || 'redis://localhost:6380',
   
-  MINIO_ENDPOINT: Deno.env.get('MINIO_ENDPOINT') || 'localhost:9000',
+  MINIO_ENDPOINT: Deno.env.get('MINIO_ENDPOINT') || 'localhost:9002',
   MINIO_USER: Deno.env.get('MINIO_USER') || 'streamflow',
-  MINIO_PASSWORD: Deno.env.get('MINIO_PASSWORD') || 'streamflow',
+  MINIO_PASSWORD: Deno.env.get('MINIO_PASSWORD') || 'streamflow123',
   MINIO_BUCKET_RAW: Deno.env.get('MINIO_BUCKET_RAW') || 'raw-uploads',
   MINIO_BUCKET_VOD: Deno.env.get('MINIO_BUCKET_VOD') || 'production-vod',
   MINIO_BUCKET_THUMBS: Deno.env.get('MINIO_BUCKET_THUMBS') || 'thumbnails',


### PR DESCRIPTION
Este PR ajusta la configuración del backend para que coincida con los puertos y credenciales de Docker Compose: se actualizaron DATABASE_URL (5434), REDIS_URL (6380), MINIO_ENDPOINT (9002) y MINIO_PASSWORD (streamflow123) en env.ts y .env.example, además de eliminar la opción allowJs no soportada por Deno en deno.json, eliminando así los errores de conexión ECONNREFUSED y el warning de configuración.