### PR TITLE
fix: usar URLs internas de Docker para comunicación frontend-backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,8 +105,8 @@ services:
     ports:
       - "3000:3000"
     environment:
-      NEXT_PUBLIC_API_URL: ${FRONTEND_URL:-https://stream.cloudjfet.site}/v1
-      NEXT_PUBLIC_MINIO_URL: ${MINIO_URL:-https://mini.cloudjfet.site}
+      NEXT_PUBLIC_API_URL: ${FRONTEND_URL:-http://backend:3001}/v1
+      NEXT_PUBLIC_MINIO_URL: ${MINIO_URL:-http://minio:9000}
     depends_on:
       - backend
     mem_limit: 512m


### PR DESCRIPTION
## Resumen

Corrige el error `ERR_CONNECTION_REFUSED` que ocurría al intentar registrarse/login en el frontend.

### Problema

El frontend tenía configurado `NEXT_PUBLIC_API_URL` apuntando a `localhost:3001` o `https://stream.cloudjfet.site/v1`. Cuando el navegador intentaba conectar al backend, `localhost` resolvía a la máquina del usuario (no al servidor), causando el error de conexión.

### Solución

Cambiar las variables de entorno para usar los hostname de los contenedores Docker en la red interna:

- `NEXT_PUBLIC_API_URL`: `http://backend:3001/v1` (antes `https://stream.cloudjfet.site/v1`)
- `NEXT_PUBLIC_MINIO_URL`: `http://minio:9000` (antes `https://mini.cloudjfet.site`)

Esto permite que el frontend (a través del reverse proxy) se comunique con el backend por la red interna de Docker.

## Test plan

- [ ] Hacer redeploy del stack en Portainer
- [ ] Verificar que el login/registro funciona correctamente
- [ ] Verificar que la carga de archivos a MinIO funciona

🤖 Generado con [Claude Code](https://claude.ai/claude-code)