### PR TITLE
fix: usar variables internas BACKEND_URL y MINIO_INTERNAL_URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,8 +105,8 @@ services:
     ports:
       - "3000:3000"
     environment:
-      NEXT_PUBLIC_API_URL: ${FRONTEND_URL:-http://backend:3001}/v1
-      NEXT_PUBLIC_MINIO_URL: ${MINIO_URL:-http://minio:9000}
+      NEXT_PUBLIC_API_URL: ${BACKEND_URL:-http://backend:3001}/v1
+      NEXT_PUBLIC_MINIO_URL: ${MINIO_INTERNAL_URL:-http://minio:9000}
     depends_on:
       - backend
     mem_limit: 512m


### PR DESCRIPTION
## Resumen

Corrige el problema donde `FRONTEND_URL` y `MINIO_URL` (URLs públicas) sobreescribían la configuración interna.

### Cambio

- `NEXT_PUBLIC_API_URL`: ahora usa `${BACKEND_URL:-http://backend:3001}/v1`
- `NEXT_PUBLIC_MINIO_URL`: ahora usa `${MINIO_INTERNAL_URL:-http://minio:9000}`

### Por qué

El compose original usaba `${FRONTEND_URL}` como variable para la API URL. Cuando el usuario configuraba `FRONTEND_URL=https://stream.cloudjfet.site`, el navegador intentaba conectar a esa URL en vez de al backend interno.

Ahora las variables `BACKEND_URL` y `MINIO_INTERNAL_URL` tienen valores por defecto que funcionan con la red interna de Docker.

## Test plan

- [ ] Redeploy en Portainer
- [ ] Verificar login/registro funciona

🤖 Generado con [Claude Code](https://claude.ai/claude-code)