### PR TITLE
fix: agregar HOSTNAME=0.0.0.0 para binding de Next.js

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,6 +13,7 @@ FROM node:20-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
+ENV HOSTNAME=0.0.0.0
 
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/standalone ./


### PR DESCRIPTION
## Resumen

Agrega `HOSTNAME=0.0.0.0` al Dockerfile del frontend para que Next.js escuche en todas las interfaces de red, no solo en la IP del contenedor.

### Problema

El servidor standalone de Next.js estaba escuchando solo en la IP interna del contenedor (`172.19.0.7`), causando 502 Bad Gateway cuando nginx intentaba conectar desde otra red Docker.

### Solución

Agregar `ENV HOSTNAME=0.0.0.0` en el Dockerfile del frontend.

## Test plan

- [ ] Redeploy en Portainer (necesita rebuild sin cache)
- [ ] Verificar que stream.cloudjfet.site responde correctamente

🤖 Generado con [Claude Code](https://claude.ai/claude-code)